### PR TITLE
Fix CurveID 4588 error

### DIFF
--- a/cfkem.go
+++ b/cfkem.go
@@ -41,6 +41,7 @@ var (
 	X25519Kyber768Draft00    = CurveID(0x6399)
 	X25519Kyber768Draft00Old = CurveID(0xfe31)
 	P256Kyber768Draft00      = CurveID(0xfe32)
+	X25519MLKEM768           = CurveID(0x11ec)
 	invalidCurveID           = CurveID(0)
 )
 
@@ -69,6 +70,8 @@ func curveIdToCirclScheme(id CurveID) kem.Scheme {
 		return hybrid.Kyber768X25519()
 	case P256Kyber768Draft00:
 		return hybrid.P256Kyber768Draft00()
+	case X25519MLKEM768:
+		return hybrid.X25519MLKEM768()
 	}
 	return nil
 }

--- a/cfkem_test.go
+++ b/cfkem_test.go
@@ -96,6 +96,7 @@ func TestHybridKEX(t *testing.T) {
 		X25519Kyber768Draft00,
 		X25519Kyber768Draft00Old,
 		P256Kyber768Draft00,
+		X25519MLKEM768,
 	} {
 		run(curveID, true, true, false, false)
 		run(curveID, true, false, false, false)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/refraction-networking/utls
 
-go 1.21
+go 1.23
+
+toolchain go1.23.1
 
 retract (
 	v1.4.1 // #218
@@ -9,7 +11,7 @@ retract (
 
 require (
 	github.com/andybalholm/brotli v1.0.6
-	github.com/cloudflare/circl v1.3.7
+	github.com/cloudflare/circl v1.5.0
 	github.com/klauspost/compress v1.17.4
 	golang.org/x/crypto v0.21.0
 	golang.org/x/net v0.23.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/andybalholm/brotli v1.0.6 h1:Yf9fFpf49Zrxb9NlQaluyE92/+X7UVHlhMNJN2sxfOI=
 github.com/andybalholm/brotli v1.0.6/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
-github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vcU=
-github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBSc8r4zxgA=
+github.com/cloudflare/circl v1.5.0 h1:hxIWksrX6XN5a1L2TI/h53AGPhNHoUBo+TD1ms9+pys=
+github.com/cloudflare/circl v1.5.0/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=
 github.com/klauspost/compress v1.17.4 h1:Ej5ixsIri7BrIjBkRZLTo6ghwrEtHFk7ijlczPW4fZ4=
 github.com/klauspost/compress v1.17.4/go.mod h1:/dCuZOvVtNoHsyb+cuJD3itjs3NbnF6KH9zAO4BDxPM=
 golang.org/x/crypto v0.21.0 h1:X31++rzVUdKhX5sWmSOFZxx8UW/ldWx55cbf08iNAMA=


### PR DESCRIPTION
```
unsupported Curve in KeyShareExtension: CurveID(4588).To mimic it, fill the Data(key) field manually
```

After this fix, latest Firefox with `security.tls.enable_kyber = true` works.